### PR TITLE
Potential fix for code scanning alert no. 11: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/main_giy.yml
+++ b/.github/workflows/main_giy.yml
@@ -13,6 +13,8 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Potential fix for [https://github.com/Qredence/GraphFleet/security/code-scanning/11](https://github.com/Qredence/GraphFleet/security/code-scanning/11)

To address the issue, we will add a `permissions` block to the `build` job in the workflow file. Since the `build` job only requires basic read access to the repository contents, we will set `contents: read` as the permission. This change ensures that the `build` job adheres to the principle of least privilege and avoids unnecessary write permissions.

The `permissions` block will be added directly under the `runs-on` key in the `build` job definition.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
